### PR TITLE
Simplify simulate_from_density

### DIFF
--- a/R/simulate_from_density.R
+++ b/R/simulate_from_density.R
@@ -1,4 +1,5 @@
 #' Simulate from density
+#'
 #' Compared with bootstrapping, the results do not reveal input values, and the
 #' empirical distribution can be smoother. The function assumes that the distribution
 #' can be aproximated using a gaussian kernel.

--- a/R/simulate_from_density.R
+++ b/R/simulate_from_density.R
@@ -8,9 +8,8 @@
 #' @examples
 #' my_vec <- c(23, 27, 26, 24, 25)
 #' simulate_from_density(my_vec, 10)
-#' @importFrom stats density rnorm
+#' @importFrom stats bw.SJ rnorm
 #' @export
 simulate_from_density <- function(vec, N = 1e5) {
-  fit <- density(vec, bw="SJ", kernel = "gaussian")
-  rnorm(N, sample(vec, size = N, replace = TRUE), fit$bw)
+  rnorm(N, sample(vec, size = N, replace = TRUE), bw.SJ(vec))
 }


### PR DESCRIPTION
Computing the density is unnecessary since all we care about is the bandwidth estimate, which can be computed cheaper.

I also fixed the roxygen2 formatting: before the change, the entire description was put into the documentation title.